### PR TITLE
Fix front-end test selectors

### DIFF
--- a/frontend/src/views/__tests__/LoginPage.spec.js
+++ b/frontend/src/views/__tests__/LoginPage.spec.js
@@ -116,7 +116,7 @@ describe('LoginPage.vue', () => {
     expect(axios.post).toHaveBeenCalledTimes(1);
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.find('.error').text()).toBe('Invalid credentials');
+    expect(wrapper.find('.error-message').text()).toBe('Invalid credentials');
     expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
   });
@@ -141,7 +141,7 @@ describe('LoginPage.vue', () => {
     await wrapper.vm.$nextTick(); // for axios promise
     await wrapper.vm.$nextTick(); // for logic after promise
 
-    expect(wrapper.find('.error').text()).toContain('Login successful, but could not determine user role.');
+    expect(wrapper.find('.error-message').text()).toContain('Login successful, but could not determine user role.');
     expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('token');
     expect(mockPush).not.toHaveBeenCalledWith(expect.stringContaining('dashboard'));
 

--- a/frontend/src/views/__tests__/RegisterPage.spec.js
+++ b/frontend/src/views/__tests__/RegisterPage.spec.js
@@ -70,7 +70,7 @@ describe('RegisterPage.vue', () => {
     vi.advanceTimersByTime(2000); // As per component's setTimeout
     vi.useRealTimers();
 
-    expect(wrapper.find('.success').text()).toContain('Registration successful!');
+    expect(wrapper.find('.success-message').text()).toContain('Registration successful!');
     expect(mockPush).toHaveBeenCalledWith('/login');
   });
 
@@ -86,7 +86,7 @@ describe('RegisterPage.vue', () => {
     expect(axios.post).toHaveBeenCalledTimes(1);
 
     await wrapper.vm.$nextTick(); // Wait for error message to render
-    expect(wrapper.find('.error').text()).toBe('Username already exists');
+    expect(wrapper.find('.error-message').text()).toBe('Username already exists');
     expect(mockPush).not.toHaveBeenCalled();
   });
 
@@ -98,6 +98,6 @@ describe('RegisterPage.vue', () => {
     await wrapper.find('form').trigger('submit.prevent');
 
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('.error').text()).toBe('Registration failed. Please try again.');
+    expect(wrapper.find('.error-message').text()).toBe('Registration failed. Please try again.');
   });
 });


### PR DESCRIPTION
## Summary
- update selectors in LoginPage.spec and RegisterPage.spec

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841474e3198832cac958fb86c706192