### PR TITLE
Fix duplicate main wrapper in App.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,8 +14,6 @@
     </header>
     <main class="main-content page-container">
       <router-view />
-    <main class="main-content page-container">
-      <router-view></router-view>
     </main>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- remove nested `<main>` wrapper in App.vue

## Testing
- `npm ci` *(fails: unable to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6841474edb88832cacea16420f78a594