### PR TITLE
Fix e2e auth validation

### DIFF
--- a/interactive-fiction-backend/src/auth/auth.controller.ts
+++ b/interactive-fiction-backend/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { UserService } from '../user/user.service';
 import { UserRole } from '../user/user.entity';
+import { RegisterDto } from './dto/register.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -12,9 +13,12 @@ export class AuthController {
   ) {}
 
   @Post('register')
-  async register(@Body() body: any) {
-    // In a real app, you'd use DTOs and validation
-    return this.userService.create(body.username, body.password, body.role || UserRole.PLAYER);
+  async register(@Body() registerDto: RegisterDto) {
+    return this.userService.create(
+      registerDto.username,
+      registerDto.password,
+      registerDto.role || UserRole.PLAYER,
+    );
   }
 
   @UseGuards(AuthGuard('local'))

--- a/interactive-fiction-backend/src/auth/dto/register.dto.ts
+++ b/interactive-fiction-backend/src/auth/dto/register.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsEnum } from 'class-validator';
+import { UserRole } from '../../user/user.entity';
+
+export class RegisterDto {
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+
+  @IsEnum(UserRole)
+  role: UserRole;
+}

--- a/interactive-fiction-backend/src/main.ts
+++ b/interactive-fiction-backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   app.setGlobalPrefix('api');
   app.enableCors({ origin: 'http://localhost:5173', credentials: true });
   await app.listen(process.env.PORT ?? 3000);

--- a/interactive-fiction-backend/test/app.e2e-spec.ts
+++ b/interactive-fiction-backend/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 // App type was imported from supertest/types, but it's not directly used in the provided snippet for app: INestApplication.
 // INestApplication itself doesn't need a generic type argument if we are not using specific methods from App that require it.
@@ -21,8 +21,8 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    // If main.ts has app.setGlobalPrefix('api'), it should be here too for AppController tests
-    // For now, keeping it as original, but ideally, this GET / would be GET /api/ if prefix is global
+    app.useGlobalPipes(new ValidationPipe());
+    app.setGlobalPrefix('api');
     await app.init();
   });
 
@@ -54,6 +54,7 @@ describe('AuthController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
     app.setGlobalPrefix('api'); // Crucial for API endpoint testing
     await app.init();
 


### PR DESCRIPTION
## Summary
- add RegisterDto with validation rules
- use RegisterDto in `AuthController`
- enable global `ValidationPipe`
- set global prefix and validation pipe in e2e tests

## Testing
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684149ed9598832ca5d5e298bac08a06