### PR TITLE
Add DTO validation for auth endpoints

### DIFF
--- a/interactive-fiction-backend/src/auth/auth.controller.ts
+++ b/interactive-fiction-backend/src/auth/auth.controller.ts
@@ -3,7 +3,8 @@ import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { UserService } from '../user/user.service';
 import { UserRole } from '../user/user.entity';
-import { RegisterDto } from './dto/register.dto';
+import { CreateUserDto } from './dto/create-user.dto';
+import { LoginDto } from './dto/login.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -13,17 +14,17 @@ export class AuthController {
   ) {}
 
   @Post('register')
-  async register(@Body() registerDto: RegisterDto) {
+  async register(@Body() createUserDto: CreateUserDto) {
     return this.userService.create(
-      registerDto.username,
-      registerDto.password,
-      registerDto.role || UserRole.PLAYER,
+      createUserDto.username,
+      createUserDto.password,
+      createUserDto.role || UserRole.PLAYER,
     );
   }
 
   @UseGuards(AuthGuard('local'))
   @Post('login')
-  async login(@Request() req) {
+  async login(@Request() req, @Body() _loginDto: LoginDto) {
     return this.authService.login(req.user);
   }
 

--- a/interactive-fiction-backend/src/auth/dto/create-user.dto.ts
+++ b/interactive-fiction-backend/src/auth/dto/create-user.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsEnum } from 'class-validator';
+import { UserRole } from '../../user/user.entity';
+
+export class CreateUserDto {
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+
+  @IsEnum(UserRole)
+  role: UserRole;
+}

--- a/interactive-fiction-backend/src/auth/dto/login.dto.ts
+++ b/interactive-fiction-backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class LoginDto {
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}

--- a/interactive-fiction-backend/test/app.e2e-spec.ts
+++ b/interactive-fiction-backend/test/app.e2e-spec.ts
@@ -157,6 +157,20 @@ describe('AuthController (e2e)', () => {
         .expect(401); // Unauthorized
     });
 
+    it('should fail to login with missing username', () => {
+      return request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ password: password })
+        .expect(400); // Validation error
+    });
+
+    it('should fail to login with missing password', () => {
+      return request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ username: uniqueUsernameLogin })
+        .expect(400); // Validation error
+    });
+
     it('should fail to login with non-existent username', () => {
       return request(app.getHttpServer())
         .post('/api/auth/login')


### PR DESCRIPTION
## Summary
- add `CreateUserDto` and `LoginDto` with class-validator
- apply the DTOs in `AuthController`
- extend e2e tests with validation cases for login

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414b9b5674832ca9dc984d2d48b987