### PR TITLE
Add real-time session events via WebSockets

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "axios": "^1.9.0",
     "three": "^0.176.0",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "socket.io-client": "^4.7.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/frontend/src/views/SessionViewPage.vue
+++ b/frontend/src/views/SessionViewPage.vue
@@ -45,10 +45,7 @@
         <div class="card event-log-card">
           <h2 class="card-title">Event Log</h2>
           <ul>
-            <li>Seraphina identified a faint magical aura around the figure.</li>
-            <li>Grom noticed the barkeep seems nervous.</li>
-            <li>Elara spotted a hidden clue on one of the wanted posters.</li>
-            <li>Session "The Tavern of Secrets" started.</li>
+            <li v-for="(evt, idx) in eventLog" :key="idx">{{ evt }}</li>
           </ul>
         </div>
       </aside>
@@ -58,6 +55,7 @@
 
 <script>
 // import MapViewer from '../components/MapViewer.vue'; // If MapViewer is to be re-integrated
+import { io } from 'socket.io-client';
 
 export default {
   name: 'SessionViewPage',
@@ -66,6 +64,8 @@ export default {
     return {
       sessionId: null,
       sessionName: "[Placeholder Session Name]", // Could be fetched
+      eventLog: [],
+      socket: null,
       // userRole: null, // Example if needed for conditional rendering not shown in template
     };
   },
@@ -80,6 +80,17 @@ export default {
     // In a real app, fetch session details here using this.sessionId
     // For example: this.fetchSessionDetails();
     // this.determineUserRole();
+
+    this.socket = io('http://localhost:3000/sessions');
+    this.socket.emit('joinSession', { sessionId: this.sessionId });
+    this.socket.on('sessionEvent', payload => {
+      this.eventLog.unshift(payload.message);
+    });
+  },
+  beforeUnmount() {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
   },
   methods: {
     // determineUserRole() {

--- a/interactive-fiction-backend/package.json
+++ b/interactive-fiction-backend/package.json
@@ -34,7 +34,8 @@
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.24"
+    "typeorm": "^0.3.24",
+    "socket.io": "^4.7.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/interactive-fiction-backend/src/session/session.controller.ts
+++ b/interactive-fiction-backend/src/session/session.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Body, Param, UseGuards, Request, ParseIntPipe, Patch, HttpCode, HttpStatus } from '@nestjs/common';
 import { SessionService } from './session.service';
+import { SessionGateway } from './session.gateway';
 import { AuthGuard } from '@nestjs/passport';
 import { EventDto } from './dto/event.dto';
 import { UserRole } from '../user/user.entity';
@@ -9,7 +10,10 @@ import { RolesGuard } from '../auth/roles.guard';
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 @Controller('sessions')
 export class SessionController {
-  constructor(private readonly sessionService: SessionService) {}
+  constructor(
+    private readonly sessionService: SessionService,
+    private readonly sessionGateway: SessionGateway,
+  ) {}
 
   @Post()
   @Roles(UserRole.MASTER)
@@ -55,7 +59,7 @@ export class SessionController {
     @Request() req,
   ) {
     // req.user is the authenticated User object from JwtStrategy
-    await this.sessionService.broadcastEventToSession(sessionId, eventDto, req.user);
+    await this.sessionGateway.broadcastEventToSession(sessionId, eventDto, req.user);
     return { message: 'Event broadcast initiated.' }; // Or simply return nothing for 204 No Content
   }
 }

--- a/interactive-fiction-backend/src/session/session.gateway.ts
+++ b/interactive-fiction-backend/src/session/session.gateway.ts
@@ -1,0 +1,58 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  MessageBody,
+  ConnectedSocket,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { SessionService } from './session.service';
+import { EventDto } from './dto/event.dto';
+import { User, UserRole } from '../user/user.entity';
+import { UnauthorizedException, NotFoundException } from '@nestjs/common';
+
+@WebSocketGateway({ namespace: '/sessions', cors: { origin: 'http://localhost:5173', credentials: true } })
+export class SessionGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(private readonly sessionService: SessionService) {}
+
+  handleConnection(client: Socket) {
+    // connection established
+  }
+
+  handleDisconnect(client: Socket) {
+    // connection closed
+  }
+
+  @SubscribeMessage('joinSession')
+  handleJoinSession(
+    @MessageBody() data: { sessionId: number },
+    @ConnectedSocket() client: Socket,
+  ) {
+    const room = String(data.sessionId);
+    client.join(room);
+    client.emit('joinedSession', { sessionId: data.sessionId });
+  }
+
+  async broadcastEventToSession(
+    sessionId: number,
+    eventDto: EventDto,
+    masterUser: User,
+  ): Promise<void> {
+    const session = await this.sessionService.getSessionById(sessionId);
+
+    if (!session) {
+      throw new NotFoundException(`Session with ID ${sessionId} not found.`);
+    }
+
+    if (session.master_id !== masterUser.id || masterUser.role !== UserRole.MASTER) {
+      throw new UnauthorizedException('You are not authorized to send an event to this session.');
+    }
+
+    this.server.to(String(sessionId)).emit('sessionEvent', { message: eventDto.message });
+  }
+}

--- a/interactive-fiction-backend/src/session/session.module.ts
+++ b/interactive-fiction-backend/src/session/session.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Session } from './session.entity';
 import { SessionService } from './session.service';
 import { SessionController } from './session.controller';
+import { SessionGateway } from './session.gateway';
 import { UserModule } from '../user/user.module';
 import { CampaignModule } from '../campaign/campaign.module'; // Import CampaignModule for campaign context
 
 @Module({
   imports: [TypeOrmModule.forFeature([Session]), UserModule, CampaignModule],
-  providers: [SessionService],
+  providers: [SessionService, SessionGateway],
   controllers: [SessionController],
-  exports: [SessionService],
+  exports: [SessionService, SessionGateway],
 })
 export class SessionModule {}

--- a/interactive-fiction-backend/src/session/session.service.ts
+++ b/interactive-fiction-backend/src/session/session.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, UnauthorizedException, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { EventDto } from './dto/event.dto';
 import { Session, SessionStatus } from './session.entity';
 import { User, UserRole } from '../user/user.entity';
 import { Campaign } from '../campaign/campaign.entity';
@@ -124,29 +123,4 @@ export class SessionService {
   }
 
   private readonly logger = new Logger(SessionService.name);
-
-  async broadcastEventToSession(sessionId: number, eventDto: EventDto, masterUser: User): Promise<void> {
-    const session = await this.getSessionById(sessionId); // Leverages existing method with relations
-
-    if (!session) {
-      throw new NotFoundException(`Session with ID ${sessionId} not found.`);
-    }
-
-    if (session.master_id !== masterUser.id || masterUser.role !== UserRole.MASTER) {
-      throw new UnauthorizedException('You are not authorized to send an event to this session.');
-    }
-    
-    if (session.status !== SessionStatus.ACTIVE) {
-      // Optional: Decide if masters can send events to PENDING or ENDED sessions.
-      // For now, let's assume only to ACTIVE sessions.
-      // throw new BadRequestException('Events can only be sent to active sessions.');
-    }
-
-    // MVP: Log the event. In the future, this would involve WebSockets.
-    this.logger.log(
-      `Event for session ${sessionId} by Master ${masterUser.username} (ID: ${masterUser.id}): "${eventDto.message}"`,
-    );
-    
-    // No return value needed for this MVP step as we are not persisting or directly responding with event data here.
-  }
 }


### PR DESCRIPTION
## Summary
- create `SessionGateway` using `@WebSocketGateway` to broadcast events
- enable gateway from `SessionController`
- expose gateway in module
- remove old log-only broadcast method
- add socket.io dependencies
- implement simple WebSocket client in `SessionViewPage.vue`

## Testing
- `npm --prefix interactive-fiction-backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414b9b1f0c832c8add29c0a12ee821