### PR TITLE
Add GLTF upload support for campaigns

### DIFF
--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -13,7 +13,22 @@
         <div class="card campaigns-card">
           <h2 class="card-title">Campaigns</h2>
           <p>Manage your game campaigns, create new adventures, and track ongoing stories.</p>
-          <button class="btn">New Campaign</button>
+          <button class="btn" @click="showForm = !showForm">New Campaign</button>
+          <form v-if="showForm" @submit.prevent="createCampaign" class="campaign-form">
+            <div class="form-group">
+              <label for="name">Name</label>
+              <input id="name" v-model="name" required />
+            </div>
+            <div class="form-group">
+              <label for="description">Description</label>
+              <textarea id="description" v-model="description"></textarea>
+            </div>
+            <div class="form-group">
+              <label for="model">GLTF Model</label>
+              <input id="model" type="file" @change="onFileChange" />
+            </div>
+            <button type="submit" class="btn">Save</button>
+          </form>
         </div>
 
         <div class="card event-manager-card">
@@ -64,9 +79,42 @@
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
   name: 'MasterDashboardPage',
-  // Add methods or data properties if needed for interactivity
+  data() {
+    return {
+      showForm: false,
+      name: '',
+      description: '',
+      file: null,
+    };
+  },
+  methods: {
+    onFileChange(e) {
+      this.file = e.target.files[0];
+    },
+    async createCampaign() {
+      const formData = new FormData();
+      formData.append('name', this.name);
+      formData.append('description', this.description);
+      if (this.file) {
+        formData.append('model', this.file);
+      }
+      const token = localStorage.getItem('token');
+      await axios.post(`${import.meta.env.VITE_API_BASE_URL}/campaigns`, formData, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      this.showForm = false;
+      this.name = '';
+      this.description = '';
+      this.file = null;
+    },
+  },
 };
 </script>
 

--- a/interactive-fiction-backend/src/campaign/campaign.controller.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.controller.ts
@@ -1,19 +1,49 @@
-import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Request, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+  UseGuards,
+  Request,
+  ParseIntPipe,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
 import { CampaignService } from './campaign.service';
 import { AuthGuard } from '@nestjs/passport';
 import { UserRole } from '../user/user.entity';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { FileStorageService } from './file-storage.service';
 
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 @Controller('campaigns')
 export class CampaignController {
-  constructor(private readonly campaignService: CampaignService) {}
+  constructor(
+    private readonly campaignService: CampaignService,
+    private readonly fileStorageService: FileStorageService,
+  ) {}
 
   @Post()
   @Roles(UserRole.MASTER)
-  create(@Body() createCampaignDto: { name: string; description: string; map_details?: any }, @Request() req) {
-    return this.campaignService.create(createCampaignDto.name, createCampaignDto.description, createCampaignDto.map_details, req.user);
+  @UseInterceptors(FileInterceptor('model'))
+  async create(
+    @UploadedFile() model: Express.Multer.File,
+    @Body() createCampaignDto: { name: string; description: string; map_details?: any },
+    @Request() req,
+  ) {
+    const modelPath = model ? await this.fileStorageService.saveModelFile(model) : undefined;
+    return this.campaignService.create(
+      createCampaignDto.name,
+      createCampaignDto.description,
+      createCampaignDto.map_details,
+      req.user,
+      modelPath,
+    );
   }
 
   @Get()
@@ -28,12 +58,22 @@ export class CampaignController {
 
   @Put(':id')
   @Roles(UserRole.MASTER)
-  update(
+  @UseInterceptors(FileInterceptor('model'))
+  async update(
     @Param('id', ParseIntPipe) id: number,
+    @UploadedFile() model: Express.Multer.File,
     @Body() updateCampaignDto: { name: string; description: string; map_details?: any },
     @Request() req,
   ) {
-    return this.campaignService.update(id, updateCampaignDto.name, updateCampaignDto.description, updateCampaignDto.map_details, req.user);
+    const modelPath = model ? await this.fileStorageService.saveModelFile(model) : undefined;
+    return this.campaignService.update(
+      id,
+      updateCampaignDto.name,
+      updateCampaignDto.description,
+      updateCampaignDto.map_details,
+      req.user,
+      modelPath,
+    );
   }
 
   @Delete(':id')

--- a/interactive-fiction-backend/src/campaign/campaign.entity.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.entity.ts
@@ -15,6 +15,9 @@ export class Campaign {
   @Column({ type: 'jsonb', nullable: true }) // Or string, as per requirement
   map_details: any; // Can be a more specific type if map structure is known
 
+  @Column({ nullable: true })
+  model_path?: string;
+
   @ManyToOne(() => User)
   master: User;
 

--- a/interactive-fiction-backend/src/campaign/campaign.module.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Campaign } from './campaign.entity';
 import { CampaignService } from './campaign.service';
 import { CampaignController } from './campaign.controller';
+import { FileStorageService } from './file-storage.service';
 import { UserModule } from '../user/user.module'; // Import UserModule for user context
 
 @Module({
   imports: [TypeOrmModule.forFeature([Campaign]), UserModule], // UserModule might be needed for auth checks
-  providers: [CampaignService],
+  providers: [CampaignService, FileStorageService],
   controllers: [CampaignController],
   exports: [CampaignService],
 })

--- a/interactive-fiction-backend/src/campaign/campaign.service.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.service.ts
@@ -11,7 +11,13 @@ export class CampaignService {
     private campaignsRepository: Repository<Campaign>,
   ) {}
 
-  async create(name: string, description: string, map_details: any, master: User): Promise<Campaign> {
+  async create(
+    name: string,
+    description: string,
+    map_details: any,
+    master: User,
+    model_path?: string,
+  ): Promise<Campaign> {
     if (master.role !== UserRole.MASTER) {
       throw new UnauthorizedException('Only Masters can create campaigns.');
     }
@@ -19,6 +25,7 @@ export class CampaignService {
       name,
       description,
       map_details,
+      model_path,
       master_id: master.id,
       master, // Store the user object as well for easier access if needed
     });
@@ -37,7 +44,14 @@ export class CampaignService {
     return campaign;
   }
 
-  async update(id: number, name: string, description: string, map_details: any, user: User): Promise<Campaign> {
+  async update(
+    id: number,
+    name: string,
+    description: string,
+    map_details: any,
+    user: User,
+    model_path?: string,
+  ): Promise<Campaign> {
     const campaign = await this.findOne(id);
     if (campaign.master_id !== user.id || user.role !== UserRole.MASTER) {
       throw new UnauthorizedException('You are not authorized to update this campaign.');
@@ -45,6 +59,9 @@ export class CampaignService {
     campaign.name = name;
     campaign.description = description;
     campaign.map_details = map_details;
+    if (model_path) {
+      campaign.model_path = model_path;
+    }
     return this.campaignsRepository.save(campaign);
   }
 

--- a/interactive-fiction-backend/src/campaign/file-storage.service.ts
+++ b/interactive-fiction-backend/src/campaign/file-storage.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { diskStorage, StorageEngine } from 'multer';
+import { extname, join } from 'path';
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
+
+@Injectable()
+export class FileStorageService {
+  getModelStorage(): StorageEngine {
+    return diskStorage({
+      destination: './uploads/models',
+      filename: (_req, file, cb) => {
+        const uniqueName = `${randomUUID()}${extname(file.originalname)}`;
+        cb(null, uniqueName);
+      },
+    });
+  }
+
+  async saveModelFile(file: Express.Multer.File): Promise<string> {
+    const uploadsDir = join('uploads', 'models');
+    await fs.mkdir(uploadsDir, { recursive: true });
+    const filename = `${randomUUID()}${extname(file.originalname)}`;
+    const filePath = join(uploadsDir, filename);
+    await fs.writeFile(filePath, file.buffer);
+    return filePath;
+  }
+}


### PR DESCRIPTION
## Summary
- allow storing uploaded GLTF files on disk
- save uploaded model path in campaigns
- enable campaign creation/update with file upload
- expose upload form on master dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414b9acadc832ca3e806efb41bb532