### PR TITLE
Improve UI with fantasy themed styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel&display=swap" rel="stylesheet">
+    <title>Rol Planner</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -74,10 +74,12 @@ export default {
 <style scoped>
 /* New styles for the global header and navigation */
 .global-header {
-  background-color: var(--color-cards-panels); /* Using card color for header bg */
+  background: linear-gradient(45deg,
+      var(--color-cards-panels),
+      var(--color-buttons-end));
   padding: 15px 30px; /* Vertical padding, horizontal padding */
-  border-bottom: 1px solid var(--color-accent-blue);
-  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+  border-bottom: 1px solid var(--color-accent-gold);
+  box-shadow: 0 2px 5px rgba(0,0,0,0.4);
   /* Ensure it spans full width if #app has max-width and margin auto for centering content */
   /* This might require #app to not have padding that restricts header width, */
   /* or header to be outside the main centered content of #app if that's the case */
@@ -107,14 +109,14 @@ export default {
 }
 
 .nav-link:hover {
-  color: var(--color-text-primary);
-  border-bottom-color: var(--color-accent-blue);
+  color: var(--color-accent-gold);
+  border-bottom-color: var(--color-accent-gold);
 }
 
 .nav-link.router-link-exact-active { /* Styling for the active link */
-  color: var(--color-text-primary);
+  color: var(--color-accent-gold);
   font-weight: bold; /* Bolder for active link */
-  border-bottom-color: var(--color-text-primary); /* Or a more prominent accent color */
+  border-bottom-color: var(--color-accent-gold); /* Or a more prominent accent color */
 }
 
 /* Example for a logout button if it were styled as a nav-link */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5,15 +5,17 @@
 /* For now, assume Georgia is available or use a common serif fallback */
 
 :root {
-  --font-primary: 'Georgia', serif;
+  --font-primary: 'Cinzel', serif;
 
-  --color-background-main: #1C1F2B;
-  --color-cards-panels: #222633;
-  --color-buttons: #2D3544;
-  --color-button-hover: #3C4F6E; /* Botón activo (hover) */
-  --color-text-primary: #FFFFFF;
-  --color-text-secondary: #D3D7E0;
-  --color-accent-blue: #3A4A66; /* Acentos azulados */
+  --color-background-main: #2a2139;
+  --color-cards-panels: #362b46;
+  --color-buttons-start: #9067c6;
+  --color-buttons-end: #4c3f63;
+  --color-button-hover: #a47bd6; /* Botón activo (hover) */
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #e0d2ff;
+  --color-accent-blue: #9067c6; /* Acentos violetas */
+  --color-accent-gold: #d6b657;
 
   /* Base font sizes from typography table */
   --font-size-titles-main: 24px;
@@ -43,7 +45,7 @@ h1, h2, h3, h4, h5, h6 {
   padding: 20px;
   margin-bottom: 20px; /* Spacing between cards */
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Subtle shadow */
-  border: 1px solid var(--color-accent-blue); /* Subtle border */
+  border: 1px solid var(--color-accent-gold); /* Subtle border */
 }
 
 .card-title {
@@ -58,29 +60,34 @@ h1, h2, h3, h4, h5, h6 {
   font-size: var(--font-size-buttons);
   font-weight: 500; /* Medium */
   color: var(--color-text-primary);
-  background-color: var(--color-buttons);
-  border: none;
+  background: linear-gradient(45deg,
+      var(--color-buttons-start),
+      var(--color-buttons-end));
+  border: 1px solid var(--color-accent-gold);
   padding: 10px 20px;
   border-radius: 6px; /* Rounded corners */
   cursor: pointer;
   text-align: center;
   text-decoration: none;
   display: inline-block;
-  transition: background-color 0.3s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); /* Effect of elevation */
+  transition: background 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); /* Effect of elevation */
 }
 
 .btn:hover {
-  background-color: var(--color-button-hover);
+  background: linear-gradient(45deg,
+      var(--color-button-hover),
+      var(--color-buttons-end));
 }
 
 /* General link styling */
 a {
-  color: var(--color-accent-blue);
+  color: var(--color-accent-gold);
   text-decoration: none;
 }
 
 a:hover {
+  color: var(--color-accent-blue);
   text-decoration: underline;
 }
 
@@ -89,9 +96,9 @@ input[type="text"],
 input[type="password"],
 input[type="email"],
 select {
-  background-color: var(--color-buttons); /* Similar to button bg */
+  background-color: var(--color-cards-panels); /* Similar to card bg */
   color: var(--color-text-primary);
-  border: 1px solid var(--color-accent-blue);
+  border: 1px solid var(--color-accent-gold);
   border-radius: 4px;
   padding: 10px;
   margin-bottom: 10px; /* Add some default margin */
@@ -104,7 +111,7 @@ input[type="email"]:focus,
 select:focus {
   outline: none;
   border-color: var(--color-text-secondary); /* Highlight focus */
-  box-shadow: 0 0 5px rgba(var(--color-accent-blue-rgb), 0.5); /* Using accent blue with alpha */
+  box-shadow: 0 0 5px var(--color-accent-gold);
 }
 
 /* Add a general container for pages to have some padding */

--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -142,7 +142,7 @@ export default {
   font-family: var(--font-primary);
   font-size: var(--font-size-buttons); /* Using button font size for consistency */
   color: var(--color-text-primary); /* Primary text for better visibility */
-  background-color: var(--color-buttons); /* Using button color */
+  background-color: var(--color-buttons-end); /* Using button color */
   padding: 10px 18px; /* Adjusted padding */
   border-radius: 6px;
   border: 1px solid var(--color-accent-blue);
@@ -208,7 +208,7 @@ export default {
 
 .event-manager-card li, .tips-card li {
   padding: 10px 5px; /* Increased padding for list items */
-  border-bottom: 1px solid var(--color-buttons); /* Subtle separator */
+  border-bottom: 1px solid var(--color-buttons-end); /* Subtle separator */
   line-height: 1.5; /* Improve readability */
 }
 

--- a/frontend/src/views/PlayerDashboardPage.vue
+++ b/frontend/src/views/PlayerDashboardPage.vue
@@ -73,7 +73,7 @@ export default {
   font-family: var(--font-primary);
   font-size: var(--font-size-buttons); /* Using button font size */
   color: var(--color-text-primary); /* Primary text for better visibility */
-  background-color: var(--color-buttons); /* Using button color */
+  background-color: var(--color-buttons-end); /* Using button color */
   padding: 10px 18px; /* Adjusted padding */
   border-radius: 6px;
   border: 1px solid var(--color-accent-blue);
@@ -113,7 +113,7 @@ export default {
 .active-campaigns-card li,
 .recent-activity-card li {
   padding: 10px 5px; /* Adjusted padding */
-  border-bottom: 1px solid var(--color-buttons);
+  border-bottom: 1px solid var(--color-buttons-end);
   line-height: 1.5; /* Improve readability */
 }
 


### PR DESCRIPTION
## Summary
- add Cinzel font and set as primary
- update color palette and button styles for a fantasy feel
- adjust navigation and card accents to match new palette

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684152f5fd5c832c83b19a5b97050dc9