### PR TITLE
Fix missing socket.io driver dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,9 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.3",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^1.0.0",
+        "@vue/test-utils": "^2.4.4"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.0.0",
+    "@vue/test-utils": "^2.4.4"
   }
 }

--- a/interactive-fiction-backend/package-lock.json
+++ b/interactive-fiction-backend/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-socket.io": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
         "bcrypt": "^6.0.0",
         "class-validator": "^0.14.0",

--- a/interactive-fiction-backend/package.json
+++ b/interactive-fiction-backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-socket.io": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",
     "passport": "^0.7.0",


### PR DESCRIPTION
## Summary
- add `@nestjs/platform-socket.io` to backend dependencies
- include `vitest` and `@vue/test-utils` dev dependencies for frontend
- update lock files

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68415868bf90832ca3ec4a82ac5d18ed