### PR TITLE
Fix campaign creation authorization

### DIFF
--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import api from '../api';
 
 export default {
   name: 'MasterDashboardPage',
@@ -102,10 +102,8 @@ export default {
       if (this.file) {
         formData.append('model', this.file);
       }
-      const token = localStorage.getItem('token');
-      await axios.post(`${import.meta.env.VITE_API_BASE_URL}/campaigns`, formData, {
+      await api.post('/campaigns', formData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'multipart/form-data',
         },
       });


### PR DESCRIPTION
## Summary
- use shared axios instance for `createCampaign` so JWT is automatically included

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `npm test --prefix interactive-fiction-backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415fbb3ca8832ca4246ee7037262a2