### PR TITLE
Configure static models path

### DIFF
--- a/interactive-fiction-backend/src/app.module.ts
+++ b/interactive-fiction-backend/src/app.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { join } from 'path';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
@@ -8,7 +10,17 @@ import { CampaignModule } from './campaign/campaign.module';
 import { SessionModule } from './session/session.module';
 
 @Module({
-  imports: [DatabaseModule, AuthModule, UserModule, CampaignModule, SessionModule],
+  imports: [
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', 'uploads', 'models'),
+      serveRoot: '/models',
+    }),
+    DatabaseModule,
+    AuthModule,
+    UserModule,
+    CampaignModule,
+    SessionModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/interactive-fiction-backend/src/campaign/file-storage.service.ts
+++ b/interactive-fiction-backend/src/campaign/file-storage.service.ts
@@ -22,6 +22,6 @@ export class FileStorageService {
     const filename = `${randomUUID()}${extname(file.originalname)}`;
     const filePath = join(uploadsDir, filename);
     await fs.writeFile(filePath, file.buffer);
-    return filePath;
+    return `/models/${filename}`;
   }
 }


### PR DESCRIPTION
## Summary
- serve uploaded models via Nest `ServeStaticModule`
- store uploaded model file paths relative to `/models`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*


------
https://chatgpt.com/codex/tasks/task_e_68417606cf6c832c856e3794be89b86b