### PR TITLE
Add camera sync event

### DIFF
--- a/interactive-fiction-backend/src/session/session.gateway.ts
+++ b/interactive-fiction-backend/src/session/session.gateway.ts
@@ -28,6 +28,24 @@ export class SessionGateway implements OnGatewayConnection, OnGatewayDisconnect 
     // connection closed
   }
 
+  @SubscribeMessage('cameraUpdate')
+  handleCameraUpdate(
+    @MessageBody()
+    data: {
+      sessionId: number;
+      position: { x: number; y: number; z: number };
+      quaternion: { x: number; y: number; z: number; w: number };
+    },
+    @ConnectedSocket() client: Socket,
+  ) {
+    const room = String(data.sessionId);
+    this.server.to(room).emit('cameraUpdate', {
+      clientId: client.id,
+      position: data.position,
+      quaternion: data.quaternion,
+    });
+  }
+
   @SubscribeMessage('joinSession')
   handleJoinSession(
     @MessageBody() data: { sessionId: number },


### PR DESCRIPTION
## Summary
- broadcast `cameraUpdate` events in session gateway
- connect MapViewer to socket.io and emit camera data
- listen for camera updates to adjust view

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684176081a58832c86535e2b7b700242