### PR TITLE
Improve GLTF error handling

### DIFF
--- a/frontend/src/components/MapViewer.vue
+++ b/frontend/src/components/MapViewer.vue
@@ -1,5 +1,8 @@
 <template>
-  <div ref="mapContainer" class="map-viewer-container"></div>
+  <div>
+    <div ref="mapContainer" class="map-viewer-container"></div>
+    <p v-if="modelLoadError" class="error-message">{{ modelLoadError }}</p>
+  </div>
 </template>
 
 <script>
@@ -22,6 +25,7 @@ export default {
       renderer: null,
       controls: null,
       animationFrameId: null,
+      modelLoadError: null,
     };
   },
   mounted() {
@@ -91,6 +95,9 @@ export default {
     loadModel() {
       if (!this.modelUrl) return;
 
+      // reset any previous error
+      this.modelLoadError = null;
+
       const loader = new GLTFLoader();
       loader.load(
         this.modelUrl,
@@ -114,10 +121,12 @@ export default {
 
           this.scene.add(this.loadedModel);
           console.log('Model loaded:', this.modelUrl);
+          this.modelLoadError = null;
         },
         undefined, // onProgress callback (optional)
         (error) => {
           console.error('An error happened during model loading:', error);
+          this.modelLoadError = `Failed to load model: ${error?.message || error}`;
         }
       );
     },
@@ -218,5 +227,16 @@ export default {
   width: 100%;
   height: 500px; /* Adjust as needed */
   border: 1px solid #ccc;
+}
+
+.error-message {
+  color: #ff6b6b;
+  background-color: rgba(255, 107, 107, 0.1);
+  border: 1px solid #ff6b6b;
+  padding: 10px;
+  border-radius: 4px;
+  margin-top: 10px;
+  text-align: center;
+  font-size: 14px;
 }
 </style>


### PR DESCRIPTION
## Summary
- show errors when GLTF models fail to load
- display friendly error text under the viewer

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68417609adec832cad510cc6d7dbddcb