### PR TITLE
Improve MapViewer resizing

### DIFF
--- a/frontend/src/components/MapViewer.vue
+++ b/frontend/src/components/MapViewer.vue
@@ -22,6 +22,7 @@ export default {
       renderer: null,
       controls: null,
       animationFrameId: null,
+      resizeObserver: null,
     };
   },
   mounted() {
@@ -86,6 +87,10 @@ export default {
 
       // Handle resize
       window.addEventListener('resize', this.onWindowResize);
+      this.resizeObserver = new ResizeObserver(() => {
+        this.onWindowResize();
+      });
+      this.resizeObserver.observe(container);
     },
 
     loadModel() {
@@ -153,6 +158,11 @@ export default {
 
     cleanupThree() {
       window.removeEventListener('resize', this.onWindowResize);
+      if (this.resizeObserver && this.$refs.mapContainer) {
+        this.resizeObserver.unobserve(this.$refs.mapContainer);
+        this.resizeObserver.disconnect();
+      }
+      this.resizeObserver = null;
       if (this.animationFrameId) {
         cancelAnimationFrame(this.animationFrameId);
       }
@@ -216,7 +226,7 @@ export default {
 <style scoped>
 .map-viewer-container {
   width: 100%;
-  height: 500px; /* Adjust as needed */
+  height: 100%;
   border: 1px solid #ccc;
 }
 </style>

--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -215,7 +215,7 @@ export default {
 }
 
 .scene-placeholder-card .placeholder-graphic {
-  min-height: 250px; /* Increased height */
+  height: 500px;
   background-color: var(--color-background-main); /* Slightly different from cards-panels for contrast */
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- adjust `.map-viewer-container` to use 100% height
- observe container resizing with `ResizeObserver`
- give the map placeholder card a fixed height

## Testing
- `npx vitest run` *(fails: 403 Forbidden when downloading vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68417609c214832c98a9461af7c36244