### PR TITLE
Fix missing serve-static module

### DIFF
--- a/interactive-fiction-backend/package.json
+++ b/interactive-fiction-backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.0.1",
+    "@nestjs/serve-static": "^4.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",
     "passport": "^0.7.0",


### PR DESCRIPTION
## Summary
- add `@nestjs/serve-static` dependency to the backend

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418591e408832c9c4f6eff077c1133