### PR TITLE
Fix MapViewer style block

### DIFF
--- a/frontend/src/components/MapViewer.vue
+++ b/frontend/src/components/MapViewer.vue
@@ -337,6 +337,7 @@ export default {
   to {
     transform: rotate(360deg);
   }
+}
 .error-message {
   color: #ff6b6b;
   background-color: rgba(255, 107, 107, 0.1);


### PR DESCRIPTION
## Summary
- close `@keyframes spin` CSS block in `MapViewer.vue`

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*
- `npm test` in `interactive-fiction-backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419d4a420c832ca1c54368343609bc