### PR TITLE
Fix JWT user id

### DIFF
--- a/interactive-fiction-backend/src/auth/jwt.strategy.ts
+++ b/interactive-fiction-backend/src/auth/jwt.strategy.ts
@@ -13,6 +13,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, username: payload.username, role: payload.role };
+    // Align returned object with User entity shape used throughout the services
+    // so `req.user.id` is available instead of `userId`.
+    return { id: payload.sub, username: payload.username, role: payload.role };
   }
 }


### PR DESCRIPTION
## Summary
- return `id` instead of `userId` in JWT strategy so services can read `req.user.id`

## Testing
- `npm test --silent` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68419fb33e84832ca897a0e14f26afe2