### PR TITLE
Implement campaign privacy and session joining

### DIFF
--- a/frontend/src/components/MapViewer.vue
+++ b/frontend/src/components/MapViewer.vue
@@ -25,7 +25,7 @@ export default {
     },
     sessionId: {
       type: Number,
-      required: true,
+      default: null,
     },
   },
   data() {
@@ -46,13 +46,15 @@ export default {
     this.loadModel();
     this.animate();
 
-    this.socket = io('http://localhost:3000/sessions');
-    this.socket.emit('joinSession', { sessionId: this.sessionId });
-    this.socket.on('cameraUpdate', payload => {
-      if (payload.clientId !== this.socket.id) {
-        this.updatePlayerView(payload.position, payload.quaternion);
-      }
-    });
+    if (this.sessionId !== null) {
+      this.socket = io('http://localhost:3000/sessions');
+      this.socket.emit('joinSession', { sessionId: this.sessionId });
+      this.socket.on('cameraUpdate', payload => {
+        if (payload.clientId !== this.socket.id) {
+          this.updatePlayerView(payload.position, payload.quaternion);
+        }
+      });
+    }
   },
   beforeUnmount() {
     this.cleanupThree();

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,7 @@ import RegisterPage from '../views/RegisterPage.vue';
 import MasterDashboardPage from '../views/MasterDashboardPage.vue';
 import PlayerDashboardPage from '../views/PlayerDashboardPage.vue';
 import SessionViewPage from '../views/SessionViewPage.vue';
+import CampaignEditorPage from '../views/CampaignEditorPage.vue';
 
 const routes = [
   { path: '/', component: HomePage },
@@ -24,6 +25,11 @@ const routes = [
     path: '/session/:id',
     component: SessionViewPage,
     meta: { requiresAuth: true } // Accessible by both Player and Master
+  },
+  {
+    path: '/campaign/:id/edit',
+    component: CampaignEditorPage,
+    meta: { requiresAuth: true, role: 'Master' }
   },
   // Redirect to home if path not found
   { path: '/:pathMatch(.*)*', redirect: '/' }

--- a/frontend/src/views/CampaignEditorPage.vue
+++ b/frontend/src/views/CampaignEditorPage.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="campaign-editor-page">
+    <MapViewer v-if="modelUrl" :model-url="modelUrl" />
+  </div>
+</template>
+
+<script>
+import MapViewer from '../components/MapViewer.vue';
+import api from '../api';
+
+export default {
+  name: 'CampaignEditorPage',
+  components: { MapViewer },
+  data() {
+    return { modelUrl: null, id: null };
+  },
+  created() {
+    this.id = this.$route.params.id;
+    this.fetchCampaign();
+  },
+  methods: {
+    async fetchCampaign() {
+      const { data } = await api.get(`/campaigns/${this.id}`);
+      if (data.model_path) {
+        const base = import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '');
+        this.modelUrl = `${base}/${data.model_path}`;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.campaign-editor-page {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/PlayerDashboardPage.vue
+++ b/frontend/src/views/PlayerDashboardPage.vue
@@ -9,6 +9,15 @@
 
     <div class="dashboard-main-content">
       <div class="dashboard-column full-width-column">
+        <div class="card sessions-card">
+          <h2 class="card-title">Available Sessions</h2>
+          <ul>
+            <li v-for="s in sessions" :key="s.id">
+              {{ s.name }} - {{ s.campaign.name }}
+              <button class="btn" @click="joinSession(s)">Join</button>
+            </li>
+          </ul>
+        </div>
         <div class="card active-campaigns-card">
           <h2 class="card-title">My Active Campaigns</h2>
           <p>You are currently participating in <strong>"The Dragon's Curse"</strong>.</p>
@@ -43,9 +52,30 @@
 </template>
 
 <script>
+import api from '../api';
 export default {
   name: 'PlayerDashboardPage',
-  // Add methods or data properties if needed for interactivity
+  data() {
+    return { sessions: [] };
+  },
+  created() {
+    this.fetchSessions();
+  },
+  methods: {
+    async fetchSessions() {
+      const { data } = await api.get('/sessions');
+      this.sessions = data;
+    },
+    async joinSession(session) {
+      let body = {};
+      if (!session.campaign.is_public) {
+        const password = prompt('Campaign password');
+        body = { joinToken: session.campaign.join_token, password };
+      }
+      await api.post(`/sessions/${session.id}/join`, body);
+      await this.fetchSessions();
+    },
+  }
 };
 </script>
 

--- a/interactive-fiction-backend/src/campaign/campaign.entity.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.entity.ts
@@ -18,6 +18,15 @@ export class Campaign {
   @Column({ nullable: true })
   model_path?: string;
 
+  @Column({ default: true })
+  is_public: boolean;
+
+  @Column({ nullable: true })
+  password_hash?: string;
+
+  @Column({ nullable: true })
+  join_token?: string;
+
   @ManyToOne(() => User)
   master: User;
 

--- a/interactive-fiction-backend/src/session/session.controller.ts
+++ b/interactive-fiction-backend/src/session/session.controller.ts
@@ -34,8 +34,17 @@ export class SessionController {
 
   @Post(':id/join')
   @Roles(UserRole.PLAYER)
-  joinSession(@Param('id', ParseIntPipe) id: number, @Request() req) {
-    return this.sessionService.joinSession(id, req.user);
+  joinSession(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() joinDto: { joinToken?: string; password?: string },
+    @Request() req,
+  ) {
+    return this.sessionService.joinSession(
+      id,
+      req.user,
+      joinDto.joinToken,
+      joinDto.password,
+    );
   }
 
   @Post(':id/leave')


### PR DESCRIPTION
## Summary
- support private/public campaigns with password and join token
- expose join link in campaigns API
- restrict campaign listing per user role
- validate join token and password when players join sessions
- display and create campaigns with privacy settings in master dashboard
- list available sessions for players to join
- allow MapViewer without session ID
- add route and view for campaign editor

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `frontend` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6841a706b128832c91e88c233c385f1c