### PR TITLE
Fix double slashes in model paths

### DIFF
--- a/frontend/src/views/CampaignEditorPage.vue
+++ b/frontend/src/views/CampaignEditorPage.vue
@@ -23,7 +23,9 @@ export default {
       const { data } = await api.get(`/campaigns/${this.id}`);
       if (data.model_path) {
         const base = import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '');
-        this.modelUrl = `${base}/${data.model_path}`;
+        const sanitizedBase = base.replace(/\/$/, '');
+        const sanitizedPath = data.model_path.replace(/^\//, '');
+        this.modelUrl = `${sanitizedBase}/${sanitizedPath}`;
       }
     },
   },

--- a/frontend/src/views/SessionViewPage.vue
+++ b/frontend/src/views/SessionViewPage.vue
@@ -102,7 +102,9 @@ export default {
         this.sessionName = data.name;
         if (data.campaign && data.campaign.model_path) {
           const base = import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '');
-          this.modelUrl = `${base}/${data.campaign.model_path}`;
+          const sanitizedBase = base.replace(/\/$/, '');
+          const sanitizedPath = data.campaign.model_path.replace(/^\//, '');
+          this.modelUrl = `${sanitizedBase}/${sanitizedPath}`;
         }
       } catch (e) {
         console.error('Failed to fetch session details:', e);


### PR DESCRIPTION
## Summary
- sanitize URL parts when building model URL

## Testing
- `npx vitest run` *(fails: 403 Forbidden to fetch vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec284bdc832c9d5974c620909eb4