### PR TITLE
Handle zipped model uploads

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,6 +89,12 @@
 - **Compatible con móvil** (al menos visor de mapas).
 - **Multiventana**: No es un videojuego. Puedes tener abiertas varias ventanas, solo una renderiza el mapa.
 
+### Carga de modelos 3D
+
+El backend acepta archivos `.glb`/`.gltf` de forma directa o un paquete `.zip` que
+contenga el modelo y sus texturas. Si se sube un zip, el servidor lo descomprime
+automáticamente y sirve el contenido desde `/models/<uuid>/`.
+
 ---
 
 ## 🚧 Estado del proyecto

--- a/interactive-fiction-backend/src/campaign/file-storage.service.ts
+++ b/interactive-fiction-backend/src/campaign/file-storage.service.ts
@@ -3,6 +3,10 @@ import { diskStorage, StorageEngine } from 'multer';
 import { extname, join } from 'path';
 import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
+import { exec as execCb } from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(execCb);
 
 @Injectable()
 export class FileStorageService {
@@ -19,7 +23,29 @@ export class FileStorageService {
   async saveModelFile(file: Express.Multer.File): Promise<string> {
     const uploadsDir = join('uploads', 'models');
     await fs.mkdir(uploadsDir, { recursive: true });
-    const filename = `${randomUUID()}${extname(file.originalname)}`;
+    const ext = extname(file.originalname).toLowerCase();
+    if (ext === '.zip') {
+      const dirName = randomUUID();
+      const dirPath = join(uploadsDir, dirName);
+      await fs.mkdir(dirPath, { recursive: true });
+      const zipPath = join(dirPath, file.originalname);
+      await fs.writeFile(zipPath, file.buffer);
+      try {
+        await exec(`unzip -q ${zipPath} -d ${dirPath}`);
+      } finally {
+        await fs.unlink(zipPath);
+      }
+      const files = await fs.readdir(dirPath);
+      const modelFile = files.find((f) =>
+        f.toLowerCase().endsWith('.gltf') || f.toLowerCase().endsWith('.glb'),
+      );
+      if (!modelFile) {
+        throw new Error('No GLTF/GLB model found in zip');
+      }
+      return `/models/${dirName}/${modelFile}`;
+    }
+
+    const filename = `${randomUUID()}${ext}`;
     const filePath = join(uploadsDir, filename);
     await fs.writeFile(filePath, file.buffer);
     return `/models/${filename}`;


### PR DESCRIPTION
## Summary
- support uploading a zip file containing the model and textures
- document 3D model upload options

## Testing
- `npm test` in `interactive-fiction-backend`
- `npm test` in `frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841f177aedc832c9e66a1fe96f178b5