### PR TITLE
Handle zipped model uploads

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,6 +89,12 @@
 - **Compatible con móvil** (al menos visor de mapas).
 - **Multiventana**: No es un videojuego. Puedes tener abiertas varias ventanas, solo una renderiza el mapa.
 
+### Carga de modelos 3D
+
+El backend acepta archivos `.glb`/`.gltf` de forma directa o un paquete `.zip` que
+contenga el modelo y sus texturas. Si se sube un zip, el servidor lo descomprime
+automáticamente y sirve el contenido desde `/models/<uuid>/`.
+
 ---
 
 ## 🚧 Estado del proyecto

--- a/interactive-fiction-backend/src/campaign/campaign.service.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Campaign } from './campaign.entity';
 import { User, UserRole } from '../user/user.entity';
+import { FileStorageService } from './file-storage.service';
 import * as bcrypt from 'bcrypt';
 import { randomBytes } from 'crypto';
 
@@ -11,6 +12,7 @@ export class CampaignService {
   constructor(
     @InjectRepository(Campaign)
     private campaignsRepository: Repository<Campaign>,
+    private readonly fileStorage: FileStorageService,
   ) {}
 
   async create(
@@ -99,6 +101,7 @@ export class CampaignService {
     if (campaign.master_id !== user.id || user.role !== UserRole.MASTER) {
       throw new UnauthorizedException('You are not authorized to delete this campaign.');
     }
+    await this.fileStorage.deleteModel(campaign.model_path);
     await this.campaignsRepository.delete(id);
   }
 }

--- a/interactive-fiction-backend/src/campaign/file-storage.service.ts
+++ b/interactive-fiction-backend/src/campaign/file-storage.service.ts
@@ -4,6 +4,15 @@ import { extname, join } from 'path';
 import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 
+// Decompression library is ESM only. Use dynamic import to avoid commonjs issues.
+type Decompress = (input: Buffer, output: string) => Promise<unknown>;
+
+// Lazily load the decompress function when needed
+async function getDecompress(): Promise<Decompress> {
+  const mod = await import('@xhmikosr/decompress');
+  return (mod.default ?? mod) as Decompress;
+}
+
 @Injectable()
 export class FileStorageService {
   getModelStorage(): StorageEngine {
@@ -19,9 +28,38 @@ export class FileStorageService {
   async saveModelFile(file: Express.Multer.File): Promise<string> {
     const uploadsDir = join('uploads', 'models');
     await fs.mkdir(uploadsDir, { recursive: true });
-    const filename = `${randomUUID()}${extname(file.originalname)}`;
+    const ext = extname(file.originalname).toLowerCase();
+    if (ext === '.zip') {
+      const dirName = randomUUID();
+      const dirPath = join(uploadsDir, dirName);
+      await fs.mkdir(dirPath, { recursive: true });
+      const decompress = await getDecompress();
+      await decompress(file.buffer, dirPath);
+      const files = await fs.readdir(dirPath);
+      const modelFile = files.find((f) =>
+        f.toLowerCase().endsWith('.gltf') || f.toLowerCase().endsWith('.glb'),
+      );
+      if (!modelFile) {
+        throw new Error('No GLTF/GLB model found in zip');
+      }
+      return `/models/${dirName}/${modelFile}`;
+    }
+
+    const filename = `${randomUUID()}${ext}`;
     const filePath = join(uploadsDir, filename);
     await fs.writeFile(filePath, file.buffer);
     return `/models/${filename}`;
+  }
+
+  async deleteModel(pathFromDb?: string): Promise<void> {
+    if (!pathFromDb) return;
+    const trimmed = pathFromDb.replace(/^\/models\//, '');
+    const parts = trimmed.split(/[/\\]/);
+    const base = join('uploads', 'models', parts[0]);
+    try {
+      await fs.rm(base, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
   }
 }


### PR DESCRIPTION
## Summary
- support uploading a zip file containing the model and textures
- document 3D model upload options
- extract zip archives with a JS library and delete models when campaigns are removed

## Testing
- `npm test --prefix interactive-fiction-backend`
- `npm test --prefix frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841f177aedc832c9e66a1fe96f178b5