### PR TITLE
Fix MapViewer render error

### DIFF
--- a/frontend/src/components/MapViewer.vue
+++ b/frontend/src/components/MapViewer.vue
@@ -30,18 +30,19 @@ export default {
   },
   data() {
     return {
-      scene: null,
-      camera: null,
-      renderer: null,
-      controls: null,
-      animationFrameId: null, 
-      loadingProgress: 0, 
+      loadingProgress: 0,
       modelLoadError: null,
-      resizeObserver: null,
-      socket: null, 
     };
   },
   mounted() {
+    this.scene = null;
+    this.camera = null;
+    this.renderer = null;
+    this.controls = null;
+    this.animationFrameId = null;
+    this.resizeObserver = null;
+    this.socket = null;
+    this.loadedModel = null;
     this.initThree();
     this.loadModel();
     this.animate();


### PR DESCRIPTION
## Summary
- avoid Vue reactivity on Three.js objects by keeping them as instance fields

## Testing
- `npm test --prefix interactive-fiction-backend`
- `npx vitest run --config frontend/vite.config.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc5c7480832c9308972181dfb1ae