### PR TITLE
Fix MapViewer initialization size

### DIFF
--- a/frontend/src/components/MapViewer.vue
+++ b/frontend/src/components/MapViewer.vue
@@ -30,18 +30,19 @@ export default {
   },
   data() {
     return {
-      scene: null,
-      camera: null,
-      renderer: null,
-      controls: null,
-      animationFrameId: null, 
-      loadingProgress: 0, 
+      loadingProgress: 0,
       modelLoadError: null,
-      resizeObserver: null,
-      socket: null, 
     };
   },
   mounted() {
+    this.scene = null;
+    this.camera = null;
+    this.renderer = null;
+    this.controls = null;
+    this.animationFrameId = null;
+    this.resizeObserver = null;
+    this.socket = null;
+    this.loadedModel = null;
     this.initThree();
     this.loadModel();
     this.animate();
@@ -308,6 +309,7 @@ export default {
 .map-viewer-container {
   width: 100%;
   height: 100%;
+  min-height: 400px; /* ensure canvas has space so WebGL framebuffer isn't zero */
   border: 1px solid #ccc;
 }
 

--- a/frontend/src/views/CampaignEditorPage.vue
+++ b/frontend/src/views/CampaignEditorPage.vue
@@ -35,6 +35,6 @@ export default {
 <style scoped>
 .campaign-editor-page {
   width: 100%;
-  height: 100%;
+  min-height: 80vh; /* give viewer vertical space */
 }
 </style>


### PR DESCRIPTION
## Summary
- set minimum height for MapViewer container
- give Campaign editor page vertical space for viewer

## Testing
- `npm test --prefix interactive-fiction-backend`
- `npx vitest run --config frontend/vite.config.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc5c7480832c9308972181dfb1ae