### PR TITLE
Improve responsive layout

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -126,84 +126,10 @@ select:focus {
   flex-direction: column;
 }
 
-/* Add any existing style.css content after these new global styles */
 
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
-}
-
+/* Layout container */
 #app {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  padding: 1rem;
 }

--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -188,30 +188,35 @@ export default {
 }
 
 .dashboard-main-content {
-  display: flex;
-  gap: 25px; /* Increased space between columns */
-  flex-wrap: wrap; /* Allow columns to wrap on smaller screens */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 25px; /* Space between columns */
 }
 
 .dashboard-column {
   display: flex;
   flex-direction: column;
-  gap: 25px; /* Increased space between cards within a column */
+  gap: 25px; /* Space between cards within a column */
 }
 
-.left-column {
-  flex: 1 1 280px; /* Flex grow, shrink, basis. Basis helps with responsiveness */
-  min-width: 280px;
+.left-column,
+.right-column {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
 }
 
 .center-column {
-  flex: 2 1 400px;
-  min-width: 300px; /* Ensure it doesn't get too squished */
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+  grid-column: span 2;
 }
 
-.right-column {
-  flex: 1 1 280px;
-  min-width: 280px;
+@media (max-width: 800px) {
+  .center-column {
+    grid-column: span 1;
+  }
 }
 
 /* Card specific styles */
@@ -283,17 +288,9 @@ export default {
    /* other properties like padding, color, bg-color are global */
 }
 
-@media (max-width: 1024px) { /* Breakpoint for larger tablets or smaller desktop views */
-  .dashboard-main-content {
-    flex-direction: column; /* Stack columns */
-  }
-  .left-column, .center-column, .right-column {
-    flex-basis: auto; /* Reset flex-basis to allow natural sizing in column flow */
-    width: 100%; /* Each column takes full width */
-    min-width: unset; /* Reset min-width if it causes issues in column layout */
-  }
+@media (max-width: 1024px) { /* Breakpoint for tablets */
   .center-column {
-    order: -1; /* Optionally move center column (e.g., map) to top on mobile */
+    grid-column: span 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- clean up old default CSS
- ensure app container uses less padding
- switch master dashboard to CSS grid for better responsiveness

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684206a000ac832c810da77acc9ea614