### PR TITLE
Improve campaigns and sessions UI

### DIFF
--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -40,9 +40,15 @@
             <p v-if="joinLink" class="join-link">Share: {{ joinLink }}</p>
           </form>
           <ul class="campaign-list">
-            <li v-for="c in campaigns" :key="c.id">
-              {{ c.name }}
-              <button class="btn" @click="openCampaign(c.id)">Open</button>
+            <li v-for="c in campaigns" :key="c.id" class="campaign-item">
+              <div class="campaign-info">
+                <strong>{{ c.name }}</strong>
+                <p class="campaign-description">{{ c.description }}</p>
+              </div>
+              <div class="campaign-actions">
+                <button class="btn" @click="openCampaign(c.id)">Open</button>
+                <button class="btn btn-danger" @click="deleteCampaign(c.id)">Delete</button>
+              </div>
             </li>
           </ul>
         </div>
@@ -152,6 +158,11 @@ export default {
     openCampaign(id) {
       this.$router.push(`/campaign/${id}/edit`);
     },
+    async deleteCampaign(id) {
+      if (!confirm('Delete this campaign?')) return;
+      await api.delete(`/campaigns/${id}`);
+      await this.fetchCampaigns();
+    },
   },
 };
 </script>
@@ -222,9 +233,43 @@ export default {
    width: 100%;
 }
 
-.campaigns-card .btn {
+.campaigns-card > .btn {
   margin-top: 15px;
   width: 100%; /* Make button full width */
+}
+
+.campaign-list {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 15px;
+}
+.campaign-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--color-buttons-end);
+}
+.campaign-item:last-child {
+  border-bottom: none;
+}
+.campaign-info {
+  flex: 1;
+}
+.campaign-description {
+  margin: 5px 0 0 0;
+  font-size: var(--font-size-lists-events);
+  color: var(--color-text-secondary);
+}
+.campaign-actions {
+  display: flex;
+  gap: 10px;
+}
+.btn-danger {
+  background-color: #d9534f;
+}
+.btn-danger:hover {
+  background-color: #c9302c;
 }
 
 .subscriptions-card .btn-secondary {

--- a/frontend/src/views/PlayerDashboardPage.vue
+++ b/frontend/src/views/PlayerDashboardPage.vue
@@ -11,9 +11,13 @@
       <div class="dashboard-column full-width-column">
         <div class="card sessions-card">
           <h2 class="card-title">Available Sessions</h2>
-          <ul>
-            <li v-for="s in sessions" :key="s.id">
-              {{ s.name }} - {{ s.campaign.name }}
+          <ul class="session-list">
+            <li v-for="s in sessions" :key="s.id" class="session-item">
+              <div class="session-info">
+                <strong>{{ s.name }}</strong>
+                <span class="session-campaign">Campaign: {{ s.campaign.name }}</span>
+                <span class="session-status">Status: {{ s.status }}</span>
+              </div>
               <button class="btn" @click="joinSession(s)">Join</button>
             </li>
           </ul>
@@ -123,6 +127,33 @@ export default {
 /* Card specific styles */
 .card {
    width: 100%; /* Ensure cards take full width of the column */
+}
+
+/* Sessions list */
+.session-list {
+  list-style: none;
+  padding-left: 0;
+  font-size: var(--font-size-lists-events);
+  color: var(--color-text-secondary);
+  margin-top: 15px;
+}
+.session-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-buttons-end);
+}
+.session-item:last-child {
+  border-bottom: none;
+}
+.session-info {
+  display: flex;
+  flex-direction: column;
+}
+.session-campaign,
+.session-status {
+  font-size: 0.9em;
 }
 
 .active-campaigns-card .btn,


### PR DESCRIPTION
## Summary
- display session details in a clearer list on Player dashboard
- show campaign info with delete option on Master dashboard

## Testing
- `npm test` in `interactive-fiction-backend`
- `npx vitest run` *(fails: cannot find 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_684206c9a704832c87b8ca6b35d57e43