### PR TITLE
Add banner and logo images

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Cinzel&display=swap" rel="stylesheet">
     <title>Rol Planner</title>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#9067c6"/>
+  <text x="100" y="100" font-family="Cinzel, serif" font-size="80" fill="#ffffff" text-anchor="middle" dominant-baseline="middle">RP</text>
+</svg>

--- a/frontend/src/assets/banner.svg
+++ b/frontend/src/assets/banner.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a2139"/>
+      <stop offset="100%" stop-color="#4c3f63"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="300" fill="url(#bg)"/>
+  <text x="600" y="160" font-family="Cinzel, serif" font-size="72" fill="#d6b657" text-anchor="middle">Rol Planner</text>
+</svg>

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="home-page-container">
+    <img src="../assets/banner.svg" alt="Rol Planner banner" class="home-banner" />
     <div class="card welcome-card">
       <h1 class="card-title">Welcome to the Interactive Fiction Platform</h1>
       <p>
@@ -51,6 +52,14 @@ export default {
   flex-direction: column;
   align-items: center; /* Centers cards horizontally */
   padding-top: 20px; /* Add some space at the top */
+}
+
+.home-banner {
+  width: 100%;
+  max-width: 1000px;
+  margin-bottom: 30px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
 
 .welcome-card, .features-card {


### PR DESCRIPTION
## Summary
- add a simple SVG logo and banner artwork
- reference logo in `index.html` as favicon
- show banner image on `HomePage`
- style banner in HomePage CSS

## Testing
- `npx vitest run` *(fails: window/document not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68420dd2df1c832c82b2e6487aec2f20