### PR TITLE
Fix master dashboard sessions and campaign listing

### DIFF
--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -55,6 +55,21 @@
 
         <div class="card sessions-card">
           <h2 class="card-title">Sessions</h2>
+          <button class="btn" @click="showSessionForm = !showSessionForm">New Session</button>
+          <form v-if="showSessionForm" @submit.prevent="createSession" class="session-form">
+            <div class="form-group">
+              <label for="sessionName">Name</label>
+              <input id="sessionName" v-model="sessionName" required />
+            </div>
+            <div class="form-group">
+              <label for="sessionCampaign">Campaign</label>
+              <select id="sessionCampaign" v-model="sessionCampaignId" required>
+                <option disabled value="">Select campaign</option>
+                <option v-for="c in campaigns" :key="c.id" :value="c.id">{{ c.name }}</option>
+              </select>
+            </div>
+            <button type="submit" class="btn">Create</button>
+          </form>
           <ul class="campaign-list">
             <li v-for="s in sessions" :key="s.id" class="campaign-item">
               <div class="campaign-info">
@@ -130,6 +145,7 @@ export default {
   data() {
     return {
       showForm: false,
+      showSessionForm: false,
       name: '',
       description: '',
       file: null,
@@ -137,6 +153,8 @@ export default {
       isPublic: true,
       campaigns: [],
       sessions: [],
+      sessionName: '',
+      sessionCampaignId: '',
       joinLink: '',
     };
   },
@@ -193,6 +211,17 @@ export default {
     },
     async startSession(id) {
       await api.patch(`/sessions/${id}/start`);
+      await this.fetchSessions();
+    },
+
+    async createSession() {
+      await api.post('/sessions', {
+        name: this.sessionName,
+        campaign_id: Number(this.sessionCampaignId),
+      });
+      this.sessionName = '';
+      this.sessionCampaignId = '';
+      this.showSessionForm = false;
       await this.fetchSessions();
     },
   },

--- a/interactive-fiction-backend/src/campaign/campaign.service.ts
+++ b/interactive-fiction-backend/src/campaign/campaign.service.ts
@@ -45,11 +45,17 @@ export class CampaignService {
 
   async findAllForUser(user: User): Promise<Campaign[]> {
     if (user.role === UserRole.MASTER) {
+      // Masters should see their own campaigns as well as any
+      // other public campaigns available on the platform.
       return this.campaignsRepository.find({
-        where: { master_id: user.id },
+        where: [
+          { master_id: user.id },
+          { is_public: true },
+        ],
         relations: ['master'],
       });
     }
+
     return this.campaignsRepository.find({
       where: { is_public: true },
       relations: ['master'],


### PR DESCRIPTION
## Summary
- show public campaigns when a master calls `/campaigns`
- let masters create sessions from the dashboard

## Testing
- `npm test` in `interactive-fiction-backend`
- `npm test` in `frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68421cd1d72c832ca6f7c2b88eed4766