### PR TITLE
Handle 401 errors globally

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -16,4 +16,18 @@ api.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      // Token might be invalid or expired. Remove it and redirect to login.
+      localStorage.removeItem('token');
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
 export default api;


### PR DESCRIPTION
## Summary
- handle unauthorized responses in the Axios client

## Testing
- `npx vitest run --environment jsdom` *(fails: missing jsdom)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842268e7238832c9c28a445401149b1