### PR TITLE
Fix missing express dependency

### DIFF
--- a/interactive-fiction-backend/package.json
+++ b/interactive-fiction-backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.0.1",
     "@nestjs/serve-static": "^4.0.0",
+    "express": "^4.21.2",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",
     "passport": "^0.7.0",


### PR DESCRIPTION
## Summary
- add `express` as a direct dependency for the backend

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842b581bc94832c826e5415886aad99