### PR TITLE
Fix campaign and session handling

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
 });
 
 api.interceptors.request.use(

--- a/frontend/src/views/MasterDashboardPage.vue
+++ b/frontend/src/views/MasterDashboardPage.vue
@@ -85,6 +85,13 @@
                 >
                   Start
                 </button>
+                <button
+                  v-if="s.status === 'Active'"
+                  class="btn"
+                  @click="endSession(s.id)"
+                >
+                  End
+                </button>
               </div>
             </li>
           </ul>
@@ -211,6 +218,11 @@ export default {
     },
     async startSession(id) {
       await api.patch(`/sessions/${id}/start`);
+      await this.fetchSessions();
+    },
+
+    async endSession(id) {
+      await api.patch(`/sessions/${id}/end`);
       await this.fetchSessions();
     },
 

--- a/frontend/src/views/PlayerDashboardPage.vue
+++ b/frontend/src/views/PlayerDashboardPage.vue
@@ -106,7 +106,6 @@ export default {
     async fetchSessions() {
       try {
         const { data } = await api.get('/sessions');
-        this.sessions = data;
         const campaigns = {};
         data.forEach(s => {
           if (s.active_players.some(p => p.id === this.userId)) {
@@ -114,6 +113,9 @@ export default {
           }
         });
         this.activeCampaigns = Object.values(campaigns);
+        this.sessions = data.filter(
+          s => campaigns[s.campaign.id] && s.status === 'Active'
+        );
       } catch (e) {
         console.error('Failed to fetch sessions:', e);
         this.sessions = [];

--- a/frontend/src/views/__tests__/PlayerDashboardPage.spec.js
+++ b/frontend/src/views/__tests__/PlayerDashboardPage.spec.js
@@ -76,8 +76,8 @@ describe('PlayerDashboardPage.vue', () => {
 
   it('loads and displays available sessions', () => {
     const items = wrapper.findAll('.session-item');
-    expect(items.length).toBe(2);
-    expect(items[0].text()).toContain('S1');
+    expect(items.length).toBe(1);
+    expect(items[0].text()).toContain('S2');
   });
 
   it('loads and displays available campaigns', () => {


### PR DESCRIPTION
## Summary
- fallback API base URL to path `/api`
- filter player sessions to active ones only
- adjust PlayerDashboardPage test expectations

## Testing
- `npm test --silent` in `interactive-fiction-backend`
- `npx vitest run --environment jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842ba65aa7c832caad920085f319b14